### PR TITLE
Fix avatar shrinking before break into mobile layout

### DIFF
--- a/app/assets/stylesheets/partials/user-cover-image.css.scss
+++ b/app/assets/stylesheets/partials/user-cover-image.css.scss
@@ -189,7 +189,7 @@
     img {
       border-radius: 3px;
       box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
-      max-width: 120px;
+      width: 109px;
     }
   }
 


### PR DESCRIPTION
Just getting rid of remnants from the old user page design.

Before:

![](https://i.imgur.com/52skqqI.jpg?1)

After:

![](https://i.imgur.com/z5bTGVM.jpg?1)